### PR TITLE
Feat/taggroups

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p ./tsconfig.build.json",
     "format": "prettier --write \"./src/**/*.ts\"",
     "format:check": "prettier --check \"./src/**/*.ts\"",
-    "lint": "eslint 'src/**/*.ts' --fix",
+    "lint": "eslint \"./src/**/*.ts\" --fix",
     "prepublish:next": "npm run build",
     "publish:next": "npm publish --access public --tag next",
     "prepublish": "npm run build",

--- a/sample/main.ts
+++ b/sample/main.ts
@@ -35,6 +35,12 @@ async function bootstrap() {
       user: 'admin',
       password: '123',
     },
+    tagGroups: [
+      {
+        name: 'Core resources',
+        tags: ['cats'],
+      },
+    ],
   };
   await RedocModule.setup('docs', app, document, redocOptions);
   await app.listen(8000);

--- a/src/interfaces/redocDocument.interface.ts
+++ b/src/interfaces/redocDocument.interface.ts
@@ -1,8 +1,9 @@
 import { OpenAPIObject } from '@nestjs/swagger';
-import { LogoOptions } from './redocOptions.interface';
+import { LogoOptions, TagGroupOptions } from './redocOptions.interface';
 
 export interface RedocDocument extends Partial<OpenAPIObject> {
   info: OpenAPIObject['info'] & {
     'x-logo'?: LogoOptions;
   };
+  'x-tagGroups': TagGroupOptions[];
 }

--- a/src/interfaces/redocOptions.interface.ts
+++ b/src/interfaces/redocOptions.interface.ts
@@ -49,6 +49,11 @@ export interface RedocOptions {
     // If auth is enabled but no password is provided the default value is "123"
     password: string;
   };
+
+  /** Vendor extensions */
+
+  /** If set, group tags in categories in the side menu. Tags not added to a group will not be displayed. */
+  tagGroups?: TagGroupOptions[];
 }
 
 export interface LogoOptions {
@@ -60,4 +65,9 @@ export interface LogoOptions {
   altText?: string;
   /** href tag for logo, it defaults to the one used in your API spec */
   href?: string;
+}
+
+export interface TagGroupOptions {
+  name: string;
+  tags: string[];
 }

--- a/src/model/options.model.ts
+++ b/src/model/options.model.ts
@@ -36,4 +36,12 @@ export const schema = (document: OpenAPIObject) =>
       user: Joi.string().default('admin'),
       password: Joi.string().default('123'),
     },
+    tagGroups: Joi.array()
+      .items(
+        Joi.object({
+          name: Joi.string(),
+          tags: Joi.array().items(Joi.string()),
+        })
+      )
+      .optional(),
   });

--- a/src/redoc-module.spec.ts
+++ b/src/redoc-module.spec.ts
@@ -3,7 +3,7 @@ import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { Test } from '@nestjs/testing';
 import 'reflect-metadata';
-import * as request from 'supertest';
+import request from 'supertest';
 import { RedocModule } from './redoc-module';
 
 describe('redoc-module', () => {
@@ -99,15 +99,9 @@ describe('redoc-module', () => {
 
     it('should throw an error for now', async () => {
       try {
-        await RedocModule.setup(
-          'some/path',
-          app,
-          swagger,
-          {
-            logo: { url: 'notaUrl' },
-          },
-          { enable: false }
-        );
+        await RedocModule.setup('some/path', app, swagger, {
+          logo: { url: 'notaUrl' },
+        });
       } catch (error) {
         // console.log(error);
         // expect(typeof error).toBe(TypeError);

--- a/src/redoc-module.ts
+++ b/src/redoc-module.ts
@@ -8,6 +8,7 @@ import pathModule from 'path';
 import { resolve } from 'url';
 import { LogoOptions, RedocDocument, RedocOptions } from './interfaces';
 import { schema } from './model/options.model';
+
 export class RedocModule {
   /**
    * Setup ReDoc frontend
@@ -173,6 +174,11 @@ export class RedocModule {
       const logoOption: Partial<LogoOptions> = { ...options.logo };
       document.info['x-logo'] = logoOption;
     }
+
+    if (options.tagGroups) {
+      document['x-tagGroups'] = options.tagGroups;
+    }
+
     return document;
   }
 }


### PR DESCRIPTION
Hello, thank you for your library ! It is really helpful ! I needed the ability to group the tags in category, so here a PR to add this functionnality.

The PR includes :
- option to use the [x-tagGroups extension](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-taggroups),
- a fix on the lint script 
- a fix in the redoc-module unit test file