### PR TITLE
fix: CSP problem in Safari

### DIFF
--- a/src/redoc-module.ts
+++ b/src/redoc-module.ts
@@ -128,7 +128,7 @@ export class RedocModule {
         // Content-Security-Policy: worker-src 'self' blob:
         res.setHeader(
           'Content-Security-Policy',
-          "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; worker-src * 'unsafe-inline' 'unsafe-eval' blob:; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"
+          "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; child-src * 'unsafe-inline' 'unsafe-eval' blob:; worker-src * 'unsafe-inline' 'unsafe-eval' blob:; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"
         );
         // whoosh
         res.send(redocHTML);


### PR DESCRIPTION
This fix: Refused to load blob because it appears in neither the child-src directive nor the default-src directive of the Content Security Policy:
```
Something went wrong...

The operation is insecure.
Stack trace
[native code]
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:80:108229
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:94:33533
e@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:94:33534
e@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:94:83796
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:88:66420
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:88:67371
Fa@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:70125
cl@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:96962
sl@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:96887
Zs@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:93917
Zs@[native code]
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:45558
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:72:4087
Yo@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:45504
Vo@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:45439
Gs@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:90702
enqueueSetState@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:64:49224
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:56:1551
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:88:66996
https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:22:2578
a@https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js:22:1422
promiseReactionJob@[native code]

ReDoc Version: 2.0.0-rc.45 
Commit: aa53416d
```
This problem appears latest Safari