### PR TITLE
feat: make ReDoc version configurable

### DIFF
--- a/src/interfaces/redocOptions.interface.ts
+++ b/src/interfaces/redocOptions.interface.ts
@@ -1,4 +1,6 @@
 export interface RedocOptions {
+  /** Version of ReDoc to use (e.g. next, latest, 2.0.0-rc.50), by default is latest */
+  redocVersion?: string;
   /** Web site title (e.g: ReDoc documentation) */
   title?: string;
   /** Web site favicon URL */

--- a/src/model/options.model.ts
+++ b/src/model/options.model.ts
@@ -3,6 +3,7 @@ import { OpenAPIObject } from '@nestjs/swagger';
 
 export const schema = (document: OpenAPIObject) =>
   Joi.object().keys({
+    redocVersion: Joi.string().default('latest'),
     title: Joi.string()
       .optional()
       .default(document.info ? document.info.title : 'Swagger documentation'),

--- a/src/redoc-module.ts
+++ b/src/redoc-module.ts
@@ -98,13 +98,14 @@ export class RedocModule {
       },
     });
     // spread redoc options
-    const { title, favicon, theme, ...otherOptions } = options;
+    const { title, favicon, theme, redocVersion, ...otherOptions } = options;
     // create render object
     const renderData = {
       data: {
         title,
         docUrl,
         favicon,
+        redocVersion,
         options: otherOptions,
         ...(theme && {
           theme: {

--- a/views/redoc.handlebars
+++ b/views/redoc.handlebars
@@ -24,7 +24,7 @@
 <body>
   <!-- we provide is specification here -->
   <div id="redoc_container"></div>
-  <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@{{data.redocVersion}}/bundles/redoc.standalone.js"> </script>
   <script>
     let themeJSON = '{{{ toJSON data.theme }}}';
     if (themeJSON === '') { themeJSON = undefined }


### PR DESCRIPTION
Current ReDoc version was quite old 2.0.0-rc.8-1 (released 2019-05-13).

This pull request adds redocVersion property to RedocOptions object that allows specifying wanted ReDoc version. Values can be 'next', 'latest' or some version (e.g. '2.0.0-rc.50'). Default value is 'latest'.
![image](https://user-images.githubusercontent.com/8341598/113618161-f2882400-965f-11eb-8b64-c94747b6b448.png)
